### PR TITLE
Hash cached games' banner filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const axios = require('axios').default;
 const os = require('os');
 const { JSDOM } = require('jsdom');
 const rpc = require('discord-rpc');
+const md5 = require('md5');
 
 app.commandLine.appendSwitch('auto-detect', 'false');
 app.commandLine.appendSwitch('no-proxy-server');
@@ -241,7 +242,7 @@ function cacheBanners(data, res) {
 			method: 'GET',
 			responseType: 'stream',
 		}).then(async (response) => {
-			response.data.pipe(fs.createWriteStream(__dirname + `\\storage\\Cache\\Games\\Images\\${data[i].DisplayName}.png`));
+			response.data.pipe(fs.createWriteStream(__dirname + `\\storage\\Cache\\Games\\Images\\${md5(data[i].DisplayName)}.png`));
 		});
 	});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "deepmerge": "^4.2.2",
                 "discord-rpc": "^4.0.1",
                 "jsdom": "^19.0.0",
+                "md5": "^2.3.0",
                 "open-term": "^2.0.4",
                 "v8-compile-cache": "^2.3.0"
             },
@@ -973,6 +974,14 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/chromium-pickle-js": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
@@ -1167,6 +1176,14 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/crypto-random-string": {
@@ -2589,6 +2606,11 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
+        "node_modules/is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
         "node_modules/is-ci": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -3032,6 +3054,16 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/md5": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+            "dependencies": {
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
             }
         },
         "node_modules/mime": {
@@ -5064,6 +5096,11 @@
                 "supports-color": "^7.1.0"
             }
         },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+        },
         "chromium-pickle-js": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
@@ -5223,6 +5260,11 @@
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
             }
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
         },
         "crypto-random-string": {
             "version": "2.0.0",
@@ -6306,6 +6348,11 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
         "is-ci": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -6641,6 +6688,16 @@
             "optional": true,
             "requires": {
                 "escape-string-regexp": "^4.0.0"
+            }
+        },
+        "md5": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+            "requires": {
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
             }
         },
         "mime": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "deepmerge": "^4.2.2",
         "discord-rpc": "^4.0.1",
         "jsdom": "^19.0.0",
+        "md5": "^2.3.0",
         "open-term": "^2.0.4",
         "v8-compile-cache": "^2.3.0"
     },

--- a/src/js/launchers/find-games.js
+++ b/src/js/launchers/find-games.js
@@ -4,6 +4,7 @@ const Steam = require('./Steam.js');
 const EpicGames = require('./EpicGames.js');
 const RiotGames = require('./RiotGames.js');
 const fs = require('fs');
+const md5 = require('md5');
 const games_blacklist = [
 	'228980', // Steamworks Common Redistributables
 ];
@@ -47,7 +48,7 @@ async function loadGames() {
 		if (fs.existsSync(__dirname.split('\\').slice(0, -3).join('\\') + '\\storage\\Cache\\Games\\Images')) {
 			const dirs = fs.readdirSync(__dirname.split('\\').slice(0, -3).join('\\') + '\\storage\\Cache\\Games\\Images');
 			const img = dirs.find(x => x.split('.')[0] === game.DisplayName);
-			banner = img ? `../storage/Cache/Games/Images/${img}` : '../icon.ico';
+			banner = img ? `../storage/Cache/Games/Images/${md5(img)}` : '../icon.ico';
 		}
 		else {
 			banner = '../icon.ico';


### PR DESCRIPTION
##  Hey

I found a bug where an error appears when trying to cache the banner of a game that has the display name with other characters like Japanese:

![Screenshot](https://user-images.githubusercontent.com/19615514/150578924-ec9ac081-edbb-44dc-9893-d87027485ea9.png)

### Solution

The solution I found was to hash the images filename, to MD5 for example.

![Screenshot](https://user-images.githubusercontent.com/19615514/150579322-8fd7d660-2db0-499c-b8f1-f1e7b174a9f1.png)
